### PR TITLE
Fix support for proxy-based REST APIs

### DIFF
--- a/_outputs.tf
+++ b/_outputs.tf
@@ -1,0 +1,14 @@
+output "api_gateway_domain_targets" {
+  value       = { for domain in var.domains : domain.domain =>
+    {
+      name = var.api_type == "http"
+        ? aws_apigatewayv2_domain_name.domain_name[domain.domain].domain_name_configuration[0].target_domain_name
+        : aws_api_gateway_domain_name.rest_domain_name[each.value.domain].hosted_zone_id
+      zone_id = var.api_type == "http" ? 
+        ? aws_apigatewayv2_domain_name.domain_name[domain.domain].domain_name_configuration[0].target_domain_name
+        : aws_api_gateway_domain_name.rest_domain_name[each.value.domain].regional_zone_id
+    }
+    if var.create_dns_record && (var.api_type == "http || var.api_type == "rest)
+  }
+  description = "Targets for creating DNS records manually"
+}

--- a/_outputs.tf
+++ b/_outputs.tf
@@ -2,11 +2,11 @@ output "api_gateway_domain_targets" {
   value       = { for domain in var.domains : domain.domain =>
     {
       name = var.api_type == "http"
-        ? aws_apigatewayv2_domain_name.domain_name[domain.domain].domain_name_configuration[0].target_domain_name
-        : aws_api_gateway_domain_name.rest_domain_name[each.value.domain].hosted_zone_id
+        ? try(aws_apigatewayv2_domain_name.domain_name[domain.domain].domain_name_configuration[0].target_domain_name, "")
+        : try(aws_api_gateway_domain_name.rest_domain_name[each.value.domain].hosted_zone_id, "")
       zone_id = var.api_type == "http" ? 
-        ? aws_apigatewayv2_domain_name.domain_name[domain.domain].domain_name_configuration[0].target_domain_name
-        : aws_api_gateway_domain_name.rest_domain_name[each.value.domain].regional_zone_id
+        ? try(aws_apigatewayv2_domain_name.domain_name[domain.domain].domain_name_configuration[0].target_domain_name, "")
+        : try(aws_api_gateway_domain_name.rest_domain_name[each.value.domain].regional_zone_id, "")
     }
     if var.create_dns_record && (var.api_type == "http || var.api_type == "rest)
   }

--- a/_outputs.tf
+++ b/_outputs.tf
@@ -1,12 +1,12 @@
 output "api_gateway_domain_targets" {
   value       = { for domain in var.domains : domain.domain =>
     {
-      name = var.api_type == "http"
+      name = (var.api_type == "http"
         ? try(aws_apigatewayv2_domain_name.domain_name[domain.domain].domain_name_configuration[0].target_domain_name, "")
-        : try(aws_api_gateway_domain_name.rest_domain_name[each.value.domain].hosted_zone_id, "")
-      zone_id = var.api_type == "http" ? 
+        : try(aws_api_gateway_domain_name.rest_domain_name[each.value.domain].hosted_zone_id, ""))
+      zone_id = (var.api_type == "http" ? 
         ? try(aws_apigatewayv2_domain_name.domain_name[domain.domain].domain_name_configuration[0].target_domain_name, "")
-        : try(aws_api_gateway_domain_name.rest_domain_name[each.value.domain].regional_zone_id, "")
+        : try(aws_api_gateway_domain_name.rest_domain_name[each.value.domain].regional_zone_id, ""))
     }
     if var.create_dns_record && (var.api_type == "http || var.api_type == "rest)
   }

--- a/_outputs.tf
+++ b/_outputs.tf
@@ -3,10 +3,10 @@ output "api_gateway_domain_targets" {
     {
       name = (var.api_type == "http"
         ? try(aws_apigatewayv2_domain_name.domain_name[domain.domain].domain_name_configuration[0].target_domain_name, "")
-        : try(aws_api_gateway_domain_name.rest_domain_name[each.value.domain].hosted_zone_id, ""))
+        : try(aws_api_gateway_domain_name.rest_domain_name[domain.domain].hosted_zone_id, ""))
       zone_id = (var.api_type == "http"
         ? try(aws_apigatewayv2_domain_name.domain_name[domain.domain].domain_name_configuration[0].target_domain_name, "")
-        : try(aws_api_gateway_domain_name.rest_domain_name[each.value.domain].regional_zone_id, ""))
+        : try(aws_api_gateway_domain_name.rest_domain_name[domain.domain].regional_zone_id, ""))
     }
     if var.create_dns_record && (var.api_type == "http" || var.api_type == "rest")
   }

--- a/_outputs.tf
+++ b/_outputs.tf
@@ -8,7 +8,7 @@ output "api_gateway_domain_targets" {
         ? try(aws_apigatewayv2_domain_name.domain_name[domain.domain].domain_name_configuration[0].target_domain_name, "")
         : try(aws_api_gateway_domain_name.rest_domain_name[each.value.domain].regional_zone_id, ""))
     }
-    if var.create_dns_record && (var.api_type == "http || var.api_type == "rest)
+    if var.create_dns_record && (var.api_type == "http" || var.api_type == "rest")
   }
   description = "Targets for creating DNS records manually"
 }

--- a/_outputs.tf
+++ b/_outputs.tf
@@ -4,7 +4,7 @@ output "api_gateway_domain_targets" {
       name = (var.api_type == "http"
         ? try(aws_apigatewayv2_domain_name.domain_name[domain.domain].domain_name_configuration[0].target_domain_name, "")
         : try(aws_api_gateway_domain_name.rest_domain_name[each.value.domain].hosted_zone_id, ""))
-      zone_id = (var.api_type == "http" ? 
+      zone_id = (var.api_type == "http"
         ? try(aws_apigatewayv2_domain_name.domain_name[domain.domain].domain_name_configuration[0].target_domain_name, "")
         : try(aws_api_gateway_domain_name.rest_domain_name[each.value.domain].regional_zone_id, ""))
     }

--- a/_variables.tf
+++ b/_variables.tf
@@ -63,6 +63,18 @@ variable "create_vpc_link" {
   default     = false
 }
 
+variable "vpc_link_target_id" {
+  description = "ARN of the resource to attach for the VPC link load balancer target"
+  type        = string
+  default     = ""
+}
+
+variable "vpc_link_target_port" {
+  description = "TCP Port of the resource to attach for the VPC link load balancer target"
+  type        = number
+  default     = 443
+}
+
 variable "create_api_key" {
   description = "Boolean variable that's evaluate the creation of an api key"
   type        = bool

--- a/_variables.tf
+++ b/_variables.tf
@@ -51,6 +51,7 @@ variable "routes" {
     integration_type = string
     integration_uri  = string
     route_mapping    = string
+    path_parameters  = list(string)
     connection_type  = string
   }))
 

--- a/_variables.tf
+++ b/_variables.tf
@@ -42,6 +42,12 @@ variable "domains" {
   }))
 }
 
+variable "create_dns_record" {
+  description = "When enabled, creates the route53 record for the custom domain"
+  type        = bool
+  default     = true
+}
+
 variable "routes" {
   description = "Routes to be created in the API"
   default     = []

--- a/domain_mapping.tf
+++ b/domain_mapping.tf
@@ -19,7 +19,7 @@ resource "aws_apigatewayv2_api_mapping" "domain_mapping" {
 }
 
 resource "aws_route53_record" "hosted_zone" {
-  for_each = { for domain in var.domains : domain.domain => domain if var.api_type == "http" }
+  for_each = { for domain in var.domains : domain.domain => domain if var.api_type == "http" && var.create_dns_record }
   name     = aws_apigatewayv2_domain_name.domain_name[each.value.domain].domain_name
   type     = "A"
   zone_id  = data.aws_route53_zone.hosted_zones[each.value.domain].id
@@ -50,7 +50,7 @@ resource "aws_api_gateway_base_path_mapping" "rest_api_mapping" {
 }
 
 resource "aws_route53_record" "rest_api_records" {
-  for_each = { for domain in var.domains : domain.domain => domain if var.api_type == "rest" }
+  for_each = { for domain in var.domains : domain.domain => domain if var.api_type == "rest" && var.create_dns_record }
   name     = aws_api_gateway_domain_name.rest_domain_name[each.value.domain].domain_name
   type     = "A"
   zone_id  = data.aws_route53_zone.hosted_zones[each.value.domain].id

--- a/rest_api.tf
+++ b/rest_api.tf
@@ -1,7 +1,7 @@
 
 resource "aws_api_gateway_rest_api" "rest_api" {
   count = var.api_type == "rest" ? 1 : 0
-  name  = var.name
+  name  = "${var.environment_name}-${var.name}-api"
   endpoint_configuration {
     types = ["REGIONAL"]
   }

--- a/rest_api.tf
+++ b/rest_api.tf
@@ -89,6 +89,7 @@ resource "aws_api_gateway_integration" "integration" {
   integration_http_method = aws_api_gateway_method.rest_method[each.value.name].http_method
   type                    = each.value.integration_type
   uri                     = each.value.integration_uri
+  request_parameters = { for path_param in try(each.value.path_parameters, []) : "integration.request.path.${path_param}" => "method.request.path.${path_param}" }
 
   connection_type = each.value.connection_type
   connection_id   = var.create_vpc_link ? aws_api_gateway_vpc_link.gateway_vpc_link[0].id : ""

--- a/rest_api.tf
+++ b/rest_api.tf
@@ -14,9 +14,9 @@ resource "aws_api_gateway_deployment" "rest_deployment" {
 
   triggers = {
     redeployment = sha1(jsonencode(flatten([
-      [ for resource in var.routes : try(aws_api_gateway_resource.rest_resource[resource.name], {}) if var.api_type == "rest" && integration.name != "root" } ],
-      [ for method in var.routes : try(aws_api_gateway_method.rest_method[method.name], {}) if var.api_type == "rest" } ],
-      [ for integration in var.routes : try(aws_api_gateway_integration.integration[integration.name], {}) if var.api_type == "rest" } ]
+      [ for resource in var.routes : try(aws_api_gateway_resource.rest_resource[resource.name], {}) if var.api_type == "rest" && integration.name != "root" ],
+      [ for method in var.routes : try(aws_api_gateway_method.rest_method[method.name], {}) if var.api_type == "rest" ],
+      [ for integration in var.routes : try(aws_api_gateway_integration.integration[integration.name], {}) if var.api_type == "rest" ]
     ])))
   }
 

--- a/rest_api.tf
+++ b/rest_api.tf
@@ -14,7 +14,7 @@ resource "aws_api_gateway_deployment" "rest_deployment" {
 
   triggers = {
     redeployment = sha1(jsonencode(flatten([
-      [ for resource in var.routes : try(aws_api_gateway_resource.rest_resource[resource.name], {}) if var.api_type == "rest" && integration.name != "root" ],
+      [ for resource in var.routes : try(aws_api_gateway_resource.rest_resource[resource.name], {}) if var.api_type == "rest" && resource.name != "root" ],
       [ for method in var.routes : try(aws_api_gateway_method.rest_method[method.name], {}) if var.api_type == "rest" ],
       [ for integration in var.routes : try(aws_api_gateway_integration.integration[integration.name], {}) if var.api_type == "rest" ]
     ])))

--- a/rest_api.tf
+++ b/rest_api.tf
@@ -13,7 +13,11 @@ resource "aws_api_gateway_deployment" "rest_deployment" {
   rest_api_id = aws_api_gateway_rest_api.rest_api[0].id
 
   triggers = {
-    redeployment = sha1(jsonencode(aws_api_gateway_rest_api.rest_api[0].body))
+    redeployment = sha1(jsonencode(flatten([
+      [ for resource in var.routes : try(aws_api_gateway_resource.rest_resource[resource.name], {}) if var.api_type == "rest" && integration.name != "root" } ],
+      [ for method in var.routes : try(aws_api_gateway_method.rest_method[method.name], {}) if var.api_type == "rest" } ],
+      [ for integration in var.routes : try(aws_api_gateway_integration.integration[integration.name], {}) if var.api_type == "rest" } ]
+    ])))
   }
 
   lifecycle {

--- a/rest_api.tf
+++ b/rest_api.tf
@@ -78,10 +78,7 @@ resource "aws_api_gateway_method" "rest_method" {
   http_method   = each.value.method
   authorization = "NONE"
 
-  dynamic "request_parameters" {
-    count   = length(try(each.value.path_parameters, [])) > 0 ? 1 : 0
-    content = { for path_param in try(each.value.path_parameters, []) : "method.request.path.${path_param}" => true }
-  }
+  request_parameters = { for path_param in try(each.value.path_parameters, []) : "method.request.path.${path_param}" => true }
 }
 
 resource "aws_api_gateway_integration" "integration" {

--- a/rest_api.tf
+++ b/rest_api.tf
@@ -94,7 +94,7 @@ resource "aws_api_gateway_integration" "integration" {
 
 resource "aws_lb" "integration_vpc_endpoint" {
   count              = var.api_type == "rest" && var.create_vpc_link ? 1 : 0
-  name               = "${var.environment_name}-${var.name}-api-gateway-integration"
+  name               = "${var.environment_name}-${var.name}-gw"
   internal           = true
   load_balancer_type = "network"
   subnets            = data.aws_subnets.private.ids

--- a/rest_api.tf
+++ b/rest_api.tf
@@ -117,6 +117,11 @@ resource "aws_lb_target_group" "vpc_integration_tg" {
   port        = var.vpc_link_target_port
   protocol    = "TCP"
   vpc_id      = data.aws_vpc.current.id
+  health_check {
+    matcher  = "200"
+    path     = "/"
+    protocol = "HTTPS"
+  }
 }
 
 resource "aws_lb_target_group_attachment" "vpc_integration_tg_attachment" {

--- a/rest_api.tf
+++ b/rest_api.tf
@@ -127,7 +127,7 @@ resource "aws_lb_target_group_attachment" "vpc_integration_tg_attachment" {
 
 resource "aws_lb_listener" "https" {
   count             = var.api_type == "rest" && var.create_vpc_link ? 1 : 0
-  load_balancer_arn = aws_alb.integration_vpc_endpoint[0].arn
+  load_balancer_arn = aws_lb.integration_vpc_endpoint[0].arn
   port              = var.vpc_link_target_port
   protocol          = "TCP"
   default_action {

--- a/rest_api.tf
+++ b/rest_api.tf
@@ -111,7 +111,7 @@ resource "aws_api_gateway_vpc_link" "gateway_vpc_link" {
 
 resource "aws_lb_target_group" "vpc_integration_tg" {
   count        = var.api_type == "rest" && var.create_vpc_link ? 1 : 0
-  name        = "tf-example-lb-alb-tg"
+  name        = "${var.environment_name}-${var.name}-tg"
   target_type = "alb"
   port        = var.vpc_link_target_port
   protocol    = "TCP"


### PR DESCRIPTION
This pull request completes the work for enabling VPC link REST APIs, as well as making it possible to support proxy paths so that the path can be passed through to the underlying APIs. Adding support for the root resource allows using an API gateway per API, instead of a single instance with paths.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
- [X] I have read the CONTRIBUTING.md doc.
- [X] I have added necessary documentation (if appropriate).
- [X] Any dependent changes have been merged and published in downstream modules.

## Further comments
Sample usage of the module for a REST API that's using proxy for VPC link (including proxy paths):
```
module "api_gateway" {
  source     = "git::https://github.com/mydeal-com-au/terraform-aws-api-gateway.git"
  depends_on = [module.eb_windows]

  for_each           = { for api in try(local.workspace.api_gateway.apis, []) : api.name => api }
  environment_name   = local.workspace.environment_name
  name               = each.value.name
  api_type           = try(each.value.api_type, "rest")
  create_vpc_link    = try(each.value.create_vpc_link, true)
  vpc_link_target_id = try(each.value.create_vpc_link, true) ? module.eb_windows[each.value.application_environment].eb_load_balancers[0] : null
  create_api_key     = try(each.value.create_api_key, false)
  domains = [
    for env_app in
    flatten([
      for environment in try(local.workspace.eb_app.environments, []) : [
        for app in environment.apps : {
          environment = environment
          app         = app
        } if try(app.use_api_gateway, false) && app.name == each.value.application_name
      ] if environment.name == each.value.application_environment
      ]) : {
      domain            = "${try(env_app.app.hostname, env_app.app.name)}.${try(local.workspace.eb_app.use_master_hosted_zone, false) ? local.workspace.master_hosted_zone : local.workspace.hosted_zone}"
      api_route_mapping = null
      zone_name         = try(local.workspace.eb_app.use_master_hosted_zone, false) ? local.workspace.master_hosted_zone : local.workspace.hosted_zone
    }
  ]
  routes = flatten([
    for env_app in
    flatten([
      for environment in try(local.workspace.eb_app.environments, []) : [
        for app in environment.apps : {
          environment = environment
          app         = app
        } if try(app.use_api_gateway, false) && app.name == each.value.application_name
      ] if environment.name == each.value.application_environment
      ]) : [
      {
        name             = "root"
        method           = try(each.value.method, "ANY")
        integration_type = try(each.value.integration_type, "HTTP_PROXY")
        integration_uri  = "https://${try(env_app.app.hostname, env_app.app.name)}.${try(local.workspace.eb_app.use_master_hosted_zone, false) ? local.workspace.master_hosted_zone : local.workspace.hosted_zone}/"
        route_mapping    = null
        path_parameters  = []
        connection_type  = try(each.value.connection_type, "VPC_LINK")
      },
      {
        name             = "${env_app.app.name}-load-balancer"
        method           = try(each.value.method, "ANY")
        integration_type = try(each.value.integration_type, "HTTP_PROXY")
        integration_uri  = "https://${try(env_app.app.hostname, env_app.app.name)}.${try(local.workspace.eb_app.use_master_hosted_zone, false) ? local.workspace.master_hosted_zone : local.workspace.hosted_zone}/{proxy}"
        route_mapping    = "{proxy+}"
        path_parameters  = ["proxy"]
        connection_type  = try(each.value.connection_type, "VPC_LINK")
      }
  ]])
}
```